### PR TITLE
Added Data to Support Multiple Clusters

### DIFF
--- a/client.py
+++ b/client.py
@@ -12,6 +12,7 @@ import utils.constants as constants
 from utils.mqtt_helper import send_typed_message, MessageType, divide_chunks
 from utils.model_helper import decode_state_dictionary, encode_state_dictionary
 from common.configuration import *
+from utils.image_helper import get_images_for_cluster
 import traceback
 
 NETWORK_STRING = ''
@@ -113,26 +114,25 @@ def publish_encoded_model(payload):
 
 
 def send_images():
-    persons_data = pickle.load(open('./data/personimages.pkl', 'rb'))
-    no_persons_data = pickle.load(open('./data/nopersonimages.pkl', 'rb'))
+    data = pickle.load(open('./data/federated-learning-data.pkl', 'rb'))
+    images_in_cluster = get_images_for_cluster(data, CLUSTER_TOPIC)
+    print("# of Images in Cluster: ", len(images_in_cluster))
 
     batch_size = DEFAULT_BATCH_SIZE
     counter = 0
-    for label, images in enumerate([no_persons_data, persons_data]):
-
-        # for chunk in divide_chunks(images, batch_size):
-        #     for sample in chunk:
-        #         image, _ = sample
-        #         publish_encoded_image(image, label)
-        #     print('Sleep after sending batch of {}'.format(batch_size))
-        #     time.sleep(1)
-
-        for image, attributes in images:
-            publish_encoded_image(image, label)
-            counter += 1
-            if counter % 15 == 0:
-                time.sleep(1)
-                print('{} images sent, sleeping for 1 second.'.format(batch_size))
+    for image, attributes in images_in_cluster:
+        label = 0
+        if "person" in attributes:
+            label = 1
+        elif "no-person" in attributes:
+            label = 0
+        else:
+            print("SOMETHING IS BROKEN WITH DATA LABELING")
+        publish_encoded_image(image, label)
+        counter += 1
+        if counter % 15 == 0:
+            time.sleep(1)
+            print('{} images sent, sleeping for 1 second.'.format(batch_size))
     print('sent all images!')
 
     end_msg = {
@@ -147,13 +147,20 @@ def send_images():
 
 def setup_data():
     global DATABLOCK, DATA_INDEX
-    persons_data = pickle.load(open('./data/personimages.pkl', 'rb'))
-    no_persons_data = pickle.load(open('./data/nopersonimages.pkl', 'rb'))
+    data = pickle.load(open('./data/federated-learning-data.pkl', 'rb'))
+    images_in_cluster = get_images_for_cluster(data, CLUSTER_TOPIC)
+    print("# of Images in Cluster: ", len(images_in_cluster))
 
-    for label, images in enumerate([no_persons_data, persons_data]):
-        for image, _ in images:
-            DATABLOCK.init_new_image(image.shape, label)
-            DATABLOCK.image_data[-1] = image
+    for image, attributes in images_in_cluster:
+        label = 0
+        if "person" in attributes:
+            label = 1
+        elif "no-person" in attributes:
+            label = 0
+        else:
+            print("SOMETHING IS BROKEN WITH DATA LABELING")
+        DATABLOCK.init_new_image(image.shape, label)
+        DATABLOCK.image_data[-1] = image
 
     DATABLOCK.shuffle_data()
 

--- a/server.py
+++ b/server.py
@@ -65,6 +65,24 @@ def index():
 
         return "server initialized and message sent"
 
+@app.route('/')
+def debug():
+    if request.method == 'GET':
+        num_clients = 2
+        operation_mode = LearningType.FEDERATED
+        clusters = {
+            "ground": operation_mode,
+        }
+        initialize_server(clusters, num_clients)
+
+        send_typed_message(
+            mqtt,
+            'server/general',
+            constants.START_LEARNING_MESSAGE,
+            MessageType.SIMPLE)
+
+        return "DEBUG - server initialized and message sent"
+
 
 @socketio.on('connect')
 def connection():

--- a/utils/image_helper.py
+++ b/utils/image_helper.py
@@ -22,3 +22,13 @@ def transform_json_data_to_image_matrix(ascii_base64_img_rep, dimensions):
     np_array = np.frombuffer(buffer, dtype=np.uint8)
     image_matrix = np.reshape(np_array, dimensions)
     return image_matrix
+
+
+def get_images_for_cluster(images, cluster_topic):
+    images_in_cluster = []
+    cluster_name = cluster_topic.split("/")[1]
+    for image, attributes in images:
+        if cluster_name in attributes:
+            images_in_cluster.append((image, attributes))
+
+    return images_in_cluster


### PR DESCRIPTION
Added federated-learning-data.pkl which contains the data for all clusters. This data will be placed on all clients and then each client will automatically use the data for its cluster as defined by the server.